### PR TITLE
pass address to useFetchUserData hook

### DIFF
--- a/packages/nextjs/components/ChallengeHeading.tsx
+++ b/packages/nextjs/components/ChallengeHeading.tsx
@@ -2,10 +2,12 @@
 
 import { CheckIcon } from "./CheckIcon";
 import clsx from "clsx";
+import { useAccount } from "wagmi";
 import { useFetchUserData } from "~~/hooks/useFetchUserData";
 
 export function ChallengeHeading({ challengeId }: { challengeId: number }) {
-  const { userData } = useFetchUserData();
+  const { address } = useAccount();
+  const { userData } = useFetchUserData({ address });
 
   const isCaptured = userData?.challenges?.items.some(challenge => Number(challenge.challengeId) === challengeId);
 

--- a/packages/nextjs/components/Header/HeaderClient.tsx
+++ b/packages/nextjs/components/Header/HeaderClient.tsx
@@ -26,7 +26,7 @@ export const HeaderClient = ({ menuLinks }: { menuLinks: ReactNode }) => {
 
   const { address: connectedAddress } = useAccount();
 
-  const { userData } = useFetchUserData();
+  const { userData } = useFetchUserData({ address: connectedAddress });
 
   const flagsCaptured = userData?.challenges?.items.length || 0;
 

--- a/packages/nextjs/components/HeroInvaders.tsx
+++ b/packages/nextjs/components/HeroInvaders.tsx
@@ -17,7 +17,7 @@ export function HeroInvaders() {
   const [rowThreeMove, setRowThreeMove] = useState("translate-x-0");
 
   const { address: connectedAddress } = useAccount();
-  const { hasCompletedChallenge1 } = useFetchUserData();
+  const { hasCompletedChallenge1 } = useFetchUserData({ address: connectedAddress });
 
   useEffect(() => {
     const interval = setInterval(() => {

--- a/packages/nextjs/components/UserData.tsx
+++ b/packages/nextjs/components/UserData.tsx
@@ -8,7 +8,7 @@ import { useFetchUserData } from "~~/hooks/useFetchUserData";
 import { getFormattedDateTime } from "~~/utils/date";
 
 export const UserData = ({ address, challenges }: { address: string; challenges: string[] }) => {
-  const { userData } = useFetchUserData();
+  const { userData } = useFetchUserData({ address });
 
   if (!userData) {
     return (

--- a/packages/nextjs/hooks/useFetchUserData.tsx
+++ b/packages/nextjs/hooks/useFetchUserData.tsx
@@ -2,7 +2,6 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { gql, request } from "graphql-request";
-import { useAccount } from "wagmi";
 import { UsersData } from "~~/types/utils";
 
 const fetchUser = async (userId: string) => {
@@ -33,9 +32,7 @@ const fetchUser = async (userId: string) => {
   return data;
 };
 
-export const useFetchUserData = () => {
-  const { address } = useAccount();
-
+export const useFetchUserData = ({ address }: { address?: string }) => {
   const { data, isLoading, isError } = useQuery<UsersData>({
     queryKey: ["user", address],
     queryFn: () => fetchUser(address || ""),


### PR DESCRIPTION
### Description: 

Fixes the problem on `/profile/{address}`. 

Earlier that page was using `useFetchUserData` hook which internally used `useAccount` to get address instead of deriving the address from pages param it was realying on connected address.

This PR updates  `useFetchUserData` to accept address as param 