### PR TITLE
Homepage tweaks and flag capture tracking

### DIFF
--- a/extension/packages/nextjs/app/page.tsx.args.mjs
+++ b/extension/packages/nextjs/app/page.tsx.args.mjs
@@ -1,0 +1,43 @@
+export const imports = `import { FlagTracker } from "~~/components/FlagTracker";`;
+
+export const description = `
+  <div className="mt-8 max-w-2xl mx-auto">
+            <p className="text-base-content mb-4">
+              This stack contains all the tools you need to play the CTF locally, from contract debugging to scripting
+              and transaction tracking.
+            </p>
+            <p className="text-base text-base-content">
+              For detailed setup instructions and documentation, check out the{" "}
+              <a
+                href="https://github.com/BuidlGuidl/ctf.buidlguidl.com/tree/extension"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="link"
+              >
+                Readme
+              </a>
+            </p>
+          </div>
+
+          <div className="mt-8 max-w-2xl mx-auto">
+            <div className="bg-base-100 p-6 rounded-lg shadow-md mb-8">
+              <h2 className="text-2xl font-bold mb-4">How to Play 🎮</h2>
+              <div className="space-y-4">
+                <p className="text-base">
+                  1. You can use the{" "}
+                  <Link href="/debug" className="link">
+                    Debug Contracts
+                  </Link>{" "}
+                  tab to interact with the challenge contracts and the solutions you deploy
+                </p>
+                <p className="text-base">
+                  2. Each challenge requires you to find a way to mint a flag NFT by solving smart contract puzzles
+                </p>
+                <p className="text-base">3. Track your progress below - there are 12 flags to capture!</p>
+              </div>
+            </div>
+            <FlagTracker />
+          </div>
+`;
+
+export const externalExtensionName = "BuidlGuidl CTF";

--- a/extension/packages/nextjs/app/page.tsx.args.mjs
+++ b/extension/packages/nextjs/app/page.tsx.args.mjs
@@ -6,8 +6,16 @@ export const description = `
               This stack contains all the tools you need to play the CTF locally, from contract debugging to scripting
               and transaction tracking.
             </p>
+            <p className="text-base-content">
+              Once you're ready to capture real flags, you'll need to deploy your solutions to Optimism and track your
+              progress at{" "}
+              <a href="https://ctf.buidlguidl.com" target="_blank" rel="noopener noreferrer" className="link">
+                ctf.buidlguidl.com
+              </a>
+              .
+            </p>
             <p className="text-base text-base-content">
-              For detailed setup instructions and documentation, check out the{" "}
+              For detailed setup instructions and deployment documentation, check out the{" "}
               <a
                 href="https://github.com/BuidlGuidl/ctf.buidlguidl.com/tree/extension"
                 target="_blank"
@@ -34,6 +42,9 @@ export const description = `
                   2. Each challenge requires you to find a way to mint a flag NFT by solving smart contract puzzles
                 </p>
                 <p className="text-base">3. Track your progress below - there are 12 flags to capture!</p>
+                <p className="text-base">
+                  4. Apply your solutions to the live challenges on Optimism to capture real flags
+                </p>
               </div>
             </div>
             <FlagTracker />

--- a/extension/packages/nextjs/components/FlagMintedNotifier.tsx
+++ b/extension/packages/nextjs/components/FlagMintedNotifier.tsx
@@ -1,0 +1,29 @@
+import { useAccount } from "wagmi";
+import { useScaffoldWatchContractEvent } from "~~/hooks/scaffold-eth";
+import { notification } from "~~/utils/scaffold-eth/notification";
+
+export const FlagMintedNotifier = ({ children }: { children: React.ReactNode }) => {
+  const { address: connectedAddress } = useAccount();
+
+  useScaffoldWatchContractEvent({
+    contractName: "NFTFlags",
+    eventName: "FlagMinted",
+    onLogs: logs => {
+      void logs.map(log => {
+        const { minter, tokenId, challengeId } = log.args as { minter: string; tokenId: bigint; challengeId: bigint };
+        if (minter && connectedAddress && minter.toLowerCase() === connectedAddress.toLowerCase()) {
+          notification.success(
+            <div>
+              <p className="font-bold mb-0">Flag Captured! 🚩</p>
+              <p className="mt-0">
+                You have captured flag #{challengeId?.toString()} (Token ID: {tokenId?.toString()})
+              </p>
+            </div>,
+          );
+        }
+      });
+    },
+  });
+
+  return <>{children}</>;
+};

--- a/extension/packages/nextjs/components/FlagMintedNotifier.tsx
+++ b/extension/packages/nextjs/components/FlagMintedNotifier.tsx
@@ -3,20 +3,82 @@
 import { useState } from "react";
 import { useAccount } from "wagmi";
 import { useScaffoldWatchContractEvent } from "~~/hooks/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
 import { notification } from "~~/utils/scaffold-eth/notification";
+
+type EventMetadata = {
+  eventKey: string;
+  blockNumber: string;
+  blockHash: string;
+  transactionHash: string;
+};
+
+type ChainStorage = {
+  [chainId: string]: {
+    events: EventMetadata[];
+    lastBlockHash?: string; // Track last known block hash to detect chain resets
+  };
+};
 
 export const FlagMintedNotifier = ({ children }: { children: React.ReactNode }) => {
   const { address: connectedAddress } = useAccount();
-  const [processedEvents, setProcessedEvents] = useState<Set<string>>(() => {
+  const configuredChainId = scaffoldConfig.targetNetworks[0].id;
+
+  const [processedEvents, setProcessedEvents] = useState<ChainStorage>(() => {
     if (typeof window !== "undefined") {
-      return new Set(JSON.parse(localStorage.getItem("processedFlagEvents") || "[]"));
+      return JSON.parse(localStorage.getItem("processedFlagEvents") || "{}");
     }
-    return new Set();
+    return {};
   });
+
+  // Helper function to check if an event has been processed for the current chain
+  const isEventProcessed = (eventKey: string, chainId: number, blockHash: string) => {
+    const chainData = processedEvents[chainId.toString()];
+    if (!chainData?.events) return false;
+
+    // For local chains, if block hash doesn't match, clear events and return false
+    if (chainId === 31337 && chainData.lastBlockHash && chainData.lastBlockHash !== blockHash) {
+      setProcessedEvents(prev => {
+        const updated = { ...prev };
+        updated[chainId.toString()] = { events: [], lastBlockHash: blockHash };
+        localStorage.setItem("processedFlagEvents", JSON.stringify(updated));
+        return updated;
+      });
+      return false;
+    }
+
+    return chainData.events.some(event => event.eventKey === eventKey);
+  };
+
+  // Helper function to store a new event for the current chain
+  const storeProcessedEvent = (eventKey: string, chainId: number, metadata: Omit<EventMetadata, "eventKey">) => {
+    const chainIdStr = chainId.toString();
+    setProcessedEvents(prev => {
+      const newEvent: EventMetadata = {
+        eventKey,
+        ...metadata,
+      };
+
+      const chainData = prev[chainIdStr] || { events: [] };
+      const updatedChainData = {
+        events: [...chainData.events, newEvent],
+        lastBlockHash: metadata.blockHash,
+      };
+
+      const updatedProcessedEvents = {
+        ...prev,
+        [chainIdStr]: updatedChainData,
+      };
+
+      localStorage.setItem("processedFlagEvents", JSON.stringify(updatedProcessedEvents));
+      return updatedProcessedEvents;
+    });
+  };
 
   useScaffoldWatchContractEvent({
     contractName: "NFTFlags",
     eventName: "FlagMinted",
+    enabled: !!connectedAddress,
     onLogs: logs => {
       if (!connectedAddress) return;
 
@@ -28,7 +90,11 @@ export const FlagMintedNotifier = ({ children }: { children: React.ReactNode }) 
         };
 
         const eventKey = `${minter}-${challengeId}-${tokenId}`;
-        if (minter.toLowerCase() === connectedAddress.toLowerCase() && !processedEvents.has(eventKey)) {
+
+        if (
+          minter.toLowerCase() === connectedAddress.toLowerCase() &&
+          !isEventProcessed(eventKey, configuredChainId, log.blockHash)
+        ) {
           notification.success(
             <div>
               <p className="font-bold mb-0">Flag Captured! 🚩</p>
@@ -37,10 +103,11 @@ export const FlagMintedNotifier = ({ children }: { children: React.ReactNode }) 
               </p>
             </div>,
           );
-          setProcessedEvents(prev => {
-            const updatedProcessedEvents = new Set([...prev, eventKey]);
-            localStorage.setItem("processedFlagEvents", JSON.stringify([...updatedProcessedEvents]));
-            return updatedProcessedEvents;
+
+          storeProcessedEvent(eventKey, configuredChainId, {
+            blockNumber: log.blockNumber.toString(),
+            blockHash: log.blockHash,
+            transactionHash: log.transactionHash,
           });
         }
       });

--- a/extension/packages/nextjs/components/FlagMintedNotifier.tsx
+++ b/extension/packages/nextjs/components/FlagMintedNotifier.tsx
@@ -1,17 +1,34 @@
+"use client";
+
+import { useState } from "react";
 import { useAccount } from "wagmi";
 import { useScaffoldWatchContractEvent } from "~~/hooks/scaffold-eth";
 import { notification } from "~~/utils/scaffold-eth/notification";
 
 export const FlagMintedNotifier = ({ children }: { children: React.ReactNode }) => {
   const { address: connectedAddress } = useAccount();
+  const [processedEvents, setProcessedEvents] = useState<Set<string>>(() => {
+    if (typeof window !== "undefined") {
+      return new Set(JSON.parse(localStorage.getItem("processedFlagEvents") || "[]"));
+    }
+    return new Set();
+  });
 
   useScaffoldWatchContractEvent({
     contractName: "NFTFlags",
     eventName: "FlagMinted",
     onLogs: logs => {
-      void logs.map(log => {
-        const { minter, tokenId, challengeId } = log.args as { minter: string; tokenId: bigint; challengeId: bigint };
-        if (minter && connectedAddress && minter.toLowerCase() === connectedAddress.toLowerCase()) {
+      if (!connectedAddress) return;
+
+      logs.forEach(log => {
+        const { minter, tokenId, challengeId } = log.args as {
+          minter: string;
+          tokenId: bigint;
+          challengeId: bigint;
+        };
+
+        const eventKey = `${minter}-${challengeId}-${tokenId}`;
+        if (minter.toLowerCase() === connectedAddress.toLowerCase() && !processedEvents.has(eventKey)) {
           notification.success(
             <div>
               <p className="font-bold mb-0">Flag Captured! 🚩</p>
@@ -20,10 +37,15 @@ export const FlagMintedNotifier = ({ children }: { children: React.ReactNode }) 
               </p>
             </div>,
           );
+          setProcessedEvents(prev => {
+            const updatedProcessedEvents = new Set([...prev, eventKey]);
+            localStorage.setItem("processedFlagEvents", JSON.stringify([...updatedProcessedEvents]));
+            return updatedProcessedEvents;
+          });
         }
       });
     },
   });
 
-  return <>{children}</>;
+  return children;
 };

--- a/extension/packages/nextjs/components/FlagTracker.tsx
+++ b/extension/packages/nextjs/components/FlagTracker.tsx
@@ -17,7 +17,7 @@ export const FlagTracker = () => {
 
   const userMintedChallengeIds = new Set(userFlags?.map(event => event.args.challengeId?.toString()) || []);
 
-  const allChallengeIds = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"];
+  const allChallengeIds = Array.from({ length: 12 }, (_, i) => (i + 1).toString());
 
   const remainingFlags = allChallengeIds.filter(id => !userMintedChallengeIds.has(id));
 

--- a/extension/packages/nextjs/components/FlagTracker.tsx
+++ b/extension/packages/nextjs/components/FlagTracker.tsx
@@ -5,18 +5,17 @@ import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
 
 export const FlagTracker = () => {
   const { address: connectedAddress } = useAccount();
-  const { data: flagEvents } = useScaffoldEventHistory({
+  const { data: userFlags } = useScaffoldEventHistory({
     contractName: "NFTFlags",
     eventName: "FlagMinted",
     fromBlock: 0n,
     watch: true,
+    filters: {
+      minter: connectedAddress,
+    },
   });
 
-  // Filter flags for the connected user
-  const userMintedFlags =
-    flagEvents?.filter(event => event.args.minter?.toLowerCase() === connectedAddress?.toLowerCase()) || [];
-
-  const userMintedChallengeIds = new Set(userMintedFlags.map(event => event.args.challengeId?.toString()));
+  const userMintedChallengeIds = new Set(userFlags?.map(event => event.args.challengeId?.toString()) || []);
 
   const allChallengeIds = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"];
 
@@ -31,8 +30,8 @@ export const FlagTracker = () => {
         <div>
           <h3 className="text-xl font-semibold mb-3">Your Captured Flags</h3>
           <div className="space-y-2">
-            {userMintedFlags.length > 0 ? (
-              userMintedFlags.map(event => (
+            {userFlags && userFlags.length > 0 ? (
+              userFlags.map(event => (
                 <div
                   key={event.args.tokenId?.toString()}
                   className="flex items-center space-x-2 bg-success/20 p-2 rounded"

--- a/extension/packages/nextjs/components/FlagTracker.tsx
+++ b/extension/packages/nextjs/components/FlagTracker.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useAccount } from "wagmi";
+import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
+
+export const FlagTracker = () => {
+  const { address: connectedAddress } = useAccount();
+  const { data: flagEvents } = useScaffoldEventHistory({
+    contractName: "NFTFlags",
+    eventName: "FlagMinted",
+    fromBlock: 0n,
+    watch: true,
+  });
+
+  // Filter flags for the connected user
+  const userMintedFlags =
+    flagEvents?.filter(event => event.args.minter?.toLowerCase() === connectedAddress?.toLowerCase()) || [];
+
+  const userMintedChallengeIds = new Set(userMintedFlags.map(event => event.args.challengeId?.toString()));
+
+  const allChallengeIds = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"];
+
+  const remainingFlags = allChallengeIds.filter(id => !userMintedChallengeIds.has(id));
+
+  return (
+    <div className="bg-base-100 p-6 rounded-lg shadow-md">
+      <h2 className="text-2xl font-bold mb-4">Flag Tracker 🚩</h2>
+      <p className="text-sm text-base-content/70 mb-4">Track your progress in capturing all 12 flags.</p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <h3 className="text-xl font-semibold mb-3">Your Captured Flags</h3>
+          <div className="space-y-2">
+            {userMintedFlags.length > 0 ? (
+              userMintedFlags.map(event => (
+                <div
+                  key={event.args.tokenId?.toString()}
+                  className="flex items-center space-x-2 bg-success/20 p-2 rounded"
+                >
+                  <span className="text-success">✓</span>
+                  <span>
+                    Flag #{event.args.challengeId?.toString()} (Token ID: {event.args.tokenId?.toString()})
+                  </span>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-base-content/70">No flags captured yet. Start solving challenges!</p>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <h3 className="text-xl font-semibold mb-3">Remaining Flags</h3>
+          <div className="space-y-2">
+            {remainingFlags.length > 0 ? (
+              remainingFlags.map(challengeId => (
+                <div key={challengeId} className="flex items-center space-x-2 bg-base-200 p-2 rounded">
+                  <span>○</span>
+                  <span>Flag #{challengeId}</span>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-base-content/70">Congratulations! You've captured all flags! 🎉</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/extension/packages/nextjs/components/FlagTracker.tsx
+++ b/extension/packages/nextjs/components/FlagTracker.tsx
@@ -1,14 +1,17 @@
 "use client";
 
+import { hardhat } from "viem/chains";
 import { useAccount } from "wagmi";
 import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
 
 export const FlagTracker = () => {
   const { address: connectedAddress } = useAccount();
   const { data: userFlags } = useScaffoldEventHistory({
     contractName: "NFTFlags",
     eventName: "FlagMinted",
-    fromBlock: 0n,
+    // Set the block number to the first block of the network where the contract was deployed
+    fromBlock: (scaffoldConfig.targetNetworks[0].id as number) === hardhat.id ? 0n : 130627582n,
     watch: true,
     filters: {
       minter: connectedAddress,

--- a/extension/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.args.mjs
+++ b/extension/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.args.mjs
@@ -1,0 +1,4 @@
+export const providerNames = "FlagMintedNotifier";
+export const providerSetups = ``;
+export const providerImports = `import { FlagMintedNotifier } from "~~/components/FlagMintedNotifier";`;
+export const providerProps = ``;


### PR DESCRIPTION
- Homepage tweaks
   - Add description + how to play
   - Add Flag tracker to know your progress

<details><summary> Homepage screenshot </summary>

![image](https://github.com/user-attachments/assets/74fe27dd-a721-4174-b58f-e0961b25ea68)

</details>

- General tweaks
   - Add flag minting tracking to notify the user when he mints a flag

Not sure if the notification system should be added in that way, had to find a hacky way to add it to the template, maybe there is a cleaner way to do it, or even to track the mints.
_Edit: If this way is an overkill, maybe I could only add it to the Debug page, since at the homepage there is the Flag tracker?_

### To test: 

1. Got to your `create-eth` repository and make sure to use main branch

2. Build the latest changes in CLI with `yarn build`

3. In other terminal: `cd externalExtensions`

4. Then: `git clone https://github.com/BuidlGuidl/ctf.buidlguidl.com.git -b extension-flagtracking`

5. From the first terminal run this command: `yarn cli -e ctf.buidlguidl.com --dev`

6. Run the 3 magical commands to test it: `yarn chain`/ `yarn deploy`/`yarn start` 



Closes #8 
Closes #9 