### PR TITLE
fix: ponder stats api

### DIFF
--- a/packages/ponder/src/api/index.ts
+++ b/packages/ponder/src/api/index.ts
@@ -8,7 +8,7 @@ ponder.get("/stats", async (c) => {
     const usersCount = await c.db.select({ value: count() }).from(c.tables.User);
     const challengesCount = await c.db.select({ value: count() }).from(c.tables.Challenge);
 
-    const lastMonth = (Date.now() - (30 * 24 * 60 * 60 * 1000)) / 1000;
+    const lastMonth = Math.floor(Date.now() / 1000) - (30 * 24 * 60 * 60);
 
     const usersCountLastMonth = await c.db.select({ value: count() }).from(c.tables.User).where(gte(c.tables.User.updated, lastMonth));
     const challengesCountLastMonth = await c.db.select({ value: count() }).from(c.tables.Challenge).where(gte(c.tables.Challenge.timestamp, lastMonth));


### PR DESCRIPTION
### Description: 

Since in earlier version division was our last operation(we divide by 1000 to convert ms => s), the final result in `lastMonth` variable was decimal 

eg: `1735405670.629`

The new changes first converts ms => s, take the math.floor value and then subtract 30 days in seconds from it. This makes sure we are always in integer land. 

Also the reason why its not breaking in dev server and breaking in prod server is in development ponder.sh [uses sqlite](https://ponder.sh/0_6/docs/query/direct-sql#sqlite) which is more lenient with type coercion, but in prod we are using postgres SQL. 


Fixes #12 